### PR TITLE
feat: include claude 3 adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "dist/node/index.d.ts",
   "browser": "release/wishful-search.js",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.8.1",
+    "@anthropic-ai/sdk": "^0.16.1",
     "@azure/openai": "^1.0.0-beta.9",
     "api": "^6.1.1",
     "openai": "^4.24.7",

--- a/src/llm-adapters.ts
+++ b/src/llm-adapters.ts
@@ -274,9 +274,12 @@ function getClaudeAdapter(anthropic: Anthropic, params?: CommonLLMParameters) {
       queryPrefix?: string,
     ) {
       try {
-        const formattedMessages = messages.filter(
-          (message) => message.role !== 'system',
-        ) as MessageParam[];
+        const formattedMessages = messages
+          .filter((message) => message.role !== 'system')
+          .map((o) => ({
+            role: o.role,
+            content: o.role === 'assistant' ? o.content.trimEnd() : o.content,
+          })) as MessageParam[];
 
         if (process.env.PRINT_WS_INTERNALS === 'yes')
           console.log(

--- a/tests/movies.run.ts
+++ b/tests/movies.run.ts
@@ -27,12 +27,28 @@ const openai = new OpenAI();
   });
 
   // Uncomment to use either Claude model
-  // const Claude2LLMAdapter = LLMAdapters.getClaudeAdapter(Anthropic.HUMAN_PROMPT, Anthropic.AI_PROMPT, anthropic, {
-  //   model: 'claude-2'
-  // })
-  // const Claude1LLMAdapter = LLMAdapters.getClaudeAdapter(Anthropic.HUMAN_PROMPT, Anthropic.AI_PROMPT, anthropic, {
-  //   model: 'claude-instant-v1'
-  // })
+  // const Claude2LLMAdapter = LLMAdapters.getClaudeLegacyAdapter(
+  //   Anthropic.HUMAN_PROMPT,
+  //   Anthropic.AI_PROMPT,
+  //   anthropic,
+  //   {
+  //     model: 'claude-2',
+  //   },
+  // );
+  // const Claude3OpusLLMAdapter = LLMAdapters.getClaudeAdapter(anthropic, {
+  //   model: 'claude-3-opus-20240229',
+  // });
+  // const Claude3SonnetLLMAdapter = LLMAdapters.getClaudeAdapter(anthropic, {
+  //   model: 'claude-3-sonnet-20240229',
+  // });
+  // const Claude2LLMAdapter = LLMAdapters.getClaudeLegacyAdapter(
+  //   Anthropic.HUMAN_PROMPT,
+  //   Anthropic.AI_PROMPT,
+  //   anthropic,
+  //   {
+  //     model: 'claude-instant-v1',
+  //   },
+  // );
 
   // Uncomment to use Mistral - make sure Ollama is running and the api port is default
   // const MistralLLMAdapter = LLMAdapters.getMistralAdapter({


### PR DESCRIPTION
- [x] Separated text and messages completions API for claude
- [x] Older claude models are accessed via `getClaudeLegacyAdapter` [here](https://github.com/hrishioa/wishful-search/blob/2c7514da1b8bb5221171c707d6d08a455ba58a52/src/llm-adapters.ts#L168)